### PR TITLE
gotoのURLをbaseURLを使った相対参照に変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,3 +287,28 @@ Codegenを使い、https://demo.playwright.dev/todomvc/#/ を対象にTODOアプ
 - 第11章　Playwrightの内部構造
   - Playwrightと他のE2EテストツールのアーキテクチャをPlaywrightを確認した
   - テストツールのアーキテクチャを意識する場面は少ないが、理解することで役立つ場面もある
+
+### 2026/03/23　TODOの編集・削除テストの実装・gotoのURLを相対参照に変更
+#### [issue #9：TODOリストの編集・削除テストを実装する]
+- `test.describe`でテストをグループ化した
+  - グループごとに`beforeEach`で前提条件を設定できることを確認した
+  - ファイル全体の`beforeEach`とグループ内の`beforeEach`を組み合わせることで重複を減らした
+- TODOの編集テストを実装した
+  - ダブルクリックで編集モードに入り、テキストを変更してEnterで確定する
+- TODOの削除テストを実装した
+  - ホバーして削除ボタンをクリックし、`toHaveCount(0)`で削除されたことを確認する
+
+#### [気づき]
+- テストは独立している方が原因の特定がしやすい
+- `test.describe`内に`beforeEach`を書くことで、グループごとに異なる前提条件を設定できる
+- `toHaveCount()`で要素の件数を確認できる
+
+#### [issue #10：gotoのURLを相対参照に変更する]
+- `playwright.config.ts`に`baseURL`を設定し、URLを一元管理できるようにした
+- `goto`のURLを絶対URLから相対参照に変更した
+
+#### [気づき]
+- `baseURL`に`#/`を含めると404エラーになる
+  - `#`はURLのフラグメントを表す記号のため、ベースURLとしては適切ではない
+  - `baseURL`はスキーム・ホスト・パスまでを設定し、フラグメント（`#`以降）は`goto`側に書くのが正しい
+- `baseURL`を設定することで、テスト対象のURLが変わっても`playwright.config.ts`だけ修正すれば済む

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
 reporter: [['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 use: {
+    baseURL: 'https://demo.playwright.dev',   // テスト対象のベースURLを一元管理する
     trace: 'on-first-retry',   // 失敗して再試行した時にログを録る
     screenshot: 'on',          // 常にスクリーンショットを撮る（または 'only-on-failure'）
     video: 'retain-on-failure', // 失敗した時だけ動画を残す

--- a/tests/todo.spec.ts
+++ b/tests/todo.spec.ts
@@ -4,8 +4,8 @@ import { clearAllTodos } from './helpers/todo-cleanup';
 
 // ファイル全体：全テストで共通の前処理
 test.beforeEach(async ({ page }) => {
-  // TODOアプリにアクセスする
-  await page.goto('https://demo.playwright.dev/todomvc/#/');
+  // baseURLを基準にルートページに遷移する（playwright.config.tsのbaseURLを参照）
+  await page.goto('/todomvc/#/');
   // 各テストの前にTODOリストを全件削除し、クリーンな状態から始める
   await clearAllTodos(page);
 });


### PR DESCRIPTION
closes #10

## 変更内容
- playwright.config.tsにbaseURLを設定し、URLを一元管理できるようにした
- gotoのURLを絶対URLから相対参照に変更した